### PR TITLE
Fix typo in docs

### DIFF
--- a/src/Plot.elm
+++ b/src/Plot.elm
@@ -196,10 +196,10 @@ id id config =
     { config | id = id }
 
 
-{-| Alter the domain's lower boundery. The function provided will
+{-| Alter the domain's lower boundary. The function provided will
  be passed the lowest y-value present in any of your series and the result will
- be the lower boundery of your series. So if you would like
- the lowest boundery to simply be the edge of your series, then set
+ be the lower boundary of your series. So if you would like
+ the lowest boundary to simply be the edge of your series, then set
  this attribute to the function `identity`.
  If you want it to always be -5, then set this attribute to the function `always -5`.
 
@@ -213,10 +213,10 @@ domainLowest toLowest ({ domain } as config) =
     { config | domain = { domain | lower = toLowest } }
 
 
-{-| Alter the domain's upper boundery. The function provided will
+{-| Alter the domain's upper boundary. The function provided will
  be passed the lowest y-value present in any of your series and the result will
- be the upper boundery of your series. So if you would like
- the lowest boundery to  always be 10, then set this attribute to the function `always 10`.
+ be the upper boundary of your series. So if you would like
+ the lowest boundary to  always be 10, then set this attribute to the function `always 10`.
 
  The default is `identity`.
 
@@ -228,7 +228,7 @@ domainHighest toHighest ({ domain } as config) =
     { config | domain = { domain | upper = toHighest } }
 
 
-{-| Provide a function to determine the lower boundery of range.
+{-| Provide a function to determine the lower boundary of range.
  See `domainLowest` and imagine we're talking about the x-axis.
 -}
 rangeLowest : (Float -> Float) -> Attribute
@@ -236,7 +236,7 @@ rangeLowest toLowest ({ range } as config) =
     { config | range = { range | lower = toLowest } }
 
 
-{-| Provide a function to determine the upper boundery of range.
+{-| Provide a function to determine the upper boundary of range.
  See `domainHighest` and imagine we're talking about the x-axis.
 -}
 rangeHighest : (Float -> Float) -> Attribute

--- a/src/Plot.elm
+++ b/src/Plot.elm
@@ -35,8 +35,8 @@ module Plot
 
 {-|
  This library aims to allow you to visualize a variety of graphs in
- an intuitve manner without comprimising flexibility regarding configuration.
- It is insprired by the elm-html api, using the `element attrs children` pattern.
+ an intuitive manner without compromising flexibility regarding configuration.
+ It is inspired by the elm-html api, using the `element attrs children` pattern.
 
  This is still in beta! The api might and probably will change!
 
@@ -88,13 +88,13 @@ import Internal.Draw exposing (..)
 import Internal.Scale exposing (..)
 
 
-{-| Convinience type to represent coordinates.
+{-| Convenience type to represent coordinates.
 -}
 type alias Point =
     ( Float, Float )
 
 
-{-| Convinience type to represent style.
+{-| Convenience type to represent style.
 -}
 type alias Style =
     List ( String, String )
@@ -324,7 +324,7 @@ plot attrs =
 
 
 {-| So this is like `plot`, except the message to is `Interaction msg`. It's a message wrapping
- your message, so you can use the build in inteactions (like the hint!) in the plot as well as adding your own.
+ your message, so you can use the build in interactions (like the hint!) in the plot as well as adding your own.
  See [this example](https://github.com/terezka/elm-plot/blob/master/examples/Interactive.elm).
 -}
 plotInteractive : List Attribute -> List (Element (Interaction msg)) -> Svg (Interaction msg)

--- a/src/Plot/Axis.elm
+++ b/src/Plot/Axis.elm
@@ -176,7 +176,7 @@ labelValues values config =
         Plot.xAxis
             [ Axis.tickValues [ 0, 1, 2, 4, 8 ] ]
 
- **Note:** If you add another attribute msgltering the values like `tickDelta` _after_ this attribute,
+ **Note:** If you add another attribute altering the values like `tickDelta` _after_ this attribute,
  then this attribute will have no effect.
 -}
 tickValues : List Float -> Attribute msg
@@ -191,7 +191,7 @@ tickValues values config =
         Plot.xAxis
             [ Axis.tickDelta 4 ]
 
- **Note:** If you add another attribute msgltering the values like `tickValues` _after_ this attribute,
+ **Note:** If you add another attribute altering the values like `tickValues` _after_ this attribute,
  then this attribute will have no effect.
 -}
 tickDelta : Float -> Attribute msg

--- a/src/Plot/Label.elm
+++ b/src/Plot/Label.elm
@@ -32,7 +32,7 @@ module Plot.Label
 @docs view, viewDynamic, viewCustom
 
 ## Style attributes
-If these attributes do not forfill your needs, try out the viewCustom! If you have
+If these attributes do not fulfill your needs, try out the viewCustom! If you have
 a suspicion that I have missed a very common configuration, then please let me know and I'll add it.
 @docs StyleAttribute, classes, displace, stroke, strokeWidth, opacity, fill, fontSize, customAttrs
 

--- a/src/Plot/Tick.elm
+++ b/src/Plot/Tick.elm
@@ -29,7 +29,7 @@ module Plot.Tick
 @docs view, viewDynamic, viewCustom
 
 ## Style attributes
-If these attributes do not forfill your needs, try out the `viewCustom`! If you have
+If these attributes do not fulfill your needs, try out the `viewCustom`! If you have
 a suspicion that I have missed a very common configuration, then please let me know and I'll add it.
 
 @docs StyleAttribute, classes, width, length, stroke, strokeWidth, opacity, customAttrs
@@ -155,7 +155,7 @@ toStyleConfig attributes =
                 ]
             ]
 
- **Note:** If you add another attribute msgltering the view like `viewDynamic` or `viewCustom` _after_ this attribute,
+ **Note:** If you add another attribute altering the view like `viewDynamic` or `viewCustom` _after_ this attribute,
  then this attribute will have no effect.
 -}
 view : List (StyleAttribute msg) -> Attribute a msg
@@ -184,7 +184,7 @@ view styles config =
                 [ Tick.viewDynamic toTickStyles ]
             ]
 
- **Note:** If you add another attribute msgltering the view like `view` or `viewCustom` _after_ this attribute,
+ **Note:** If you add another attribute altering the view like `view` or `viewCustom` _after_ this attribute,
  then this attribute will have no effect.
 -}
 viewDynamic : (a -> List (StyleAttribute msg)) -> Attribute a msg
@@ -212,7 +212,7 @@ viewDynamic toStyles config =
                 [ Tick.viewCustom viewTick ]
             ]
 
- **Note:** If you add another attribute msgltering the view like `view` or `viewDynamic` _after_ this attribute,
+ **Note:** If you add another attribute altering the view like `view` or `viewDynamic` _after_ this attribute,
  then this attribute will have no effect.
 -}
 viewCustom : (a -> Svg.Svg msg) -> Attribute a msg


### PR DESCRIPTION
Changed bound**e**ry to bound**a**ry. And several other typos.