### PR TITLE
Fix SmoothLines example and use Point type for all examples

### DIFF
--- a/examples/Bars.elm
+++ b/examples/Bars.elm
@@ -8,12 +8,12 @@ import Plot.Axis as Axis
 import Plot.Bars as Bars
 
 
-data1 : List ( Float, Float )
+data1 : List ( Point )
 data1 =
     [ ( 0, 2 ), ( 1, 4 ), ( 2, 5 ), ( 3, 10 ) ]
 
 
-data2 : List ( Float, Float )
+data2 : List ( Point )
 data2 =
     [ ( 0, 0 ), ( 1, 5 ), ( 2, 7 ), ( 3, 15 ) ]
 

--- a/examples/Gradient.elm
+++ b/examples/Gradient.elm
@@ -10,7 +10,7 @@ import Plot.Axis as Axis
 -- Example inspired by https://developer.mozilla.org/en-US/docs/Web/SVG/Tutorial/Gradients
 
 
-data : List ( Float, Float )
+data : List Point
 data =
     [ ( 0, 10 ), ( 2, 12 ), ( 4, 27 ), ( 6, 25 ), ( 8, 46 ) ]
 

--- a/examples/Interactive.elm
+++ b/examples/Interactive.elm
@@ -55,12 +55,12 @@ update msg model =
 -- VIEW
 
 
-data1 : List ( Float, Float )
+data1 : List Point
 data1 =
     [ ( 0, 2 ), ( 1, 4 ), ( 2, 5 ), ( 3, 10 ) ]
 
 
-data2 : List ( Float, Float )
+data2 : List Point
 data2 =
     [ ( 0, 0 ), ( 1, 5 ), ( 2, 7 ), ( 3, 15 ) ]
 

--- a/examples/SmoothLines.elm
+++ b/examples/SmoothLines.elm
@@ -3,23 +3,22 @@ module SmoothLines exposing (..)
 import Svg
 import Html exposing (h1, p, text, div, node)
 import Html.Attributes
-import Plot.Types exposing (..)
 import Plot exposing (..)
 import Plot.Line as Line
 import Plot.Axis as Axis
 
 
-data1 : List ( Float, Float )
+data1 : List Point
 data1 =
     [ ( 0, 0 ), ( 1, 1 ), ( 2, 2 ), ( 3, 3 ), ( 4, 5 ), ( 5, 8 ), ( 6, 13 ), ( 7, 21 ), ( 8, 34 ), ( 9, 55 ), ( 10, 87 ) ]
 
 
-data2 : List ( Float, Float )
+data2 : List Point
 data2 =
     [ ( 0, 40 ), ( 1, 45 ), ( 2, 35 ), ( 3, 50 ), ( 4, 30 ), ( 5, 55 ), ( 6, 20 ), ( 7, 60 ), ( 8, 15 ), ( 9, 65 ), ( 10, 10 ) ]
 
 
-data3 : List ( Float, Float )
+data3 : List Point
 data3 =
     [ ( 0, 60 )
     , ( 1, 60 )


### PR DESCRIPTION
Uses the now through `Plot` exposed `Point` type.