### PR TITLE
Fix SmoothLines example and use Point type for all examples; without duplicating definition of Point

### DIFF
--- a/examples/Bars.elm
+++ b/examples/Bars.elm
@@ -2,13 +2,14 @@ module Bars exposing (..)
 
 import Svg
 import Html exposing (div)
+import Plot.Types exposing (Point)
 import Plot exposing (..)
 import Plot.Line as Line
 import Plot.Axis as Axis
 import Plot.Bars as Bars
 
 
-data1 : List ( Float, Float )
+data1 : List Point
 data1 =
     [ ( 0, 2 ), ( 1, 4 ), ( 2, 5 ), ( 3, 10 ) ]
 

--- a/examples/Gradient.elm
+++ b/examples/Gradient.elm
@@ -2,6 +2,7 @@ module Gradient exposing (..)
 
 import Svg
 import Svg.Attributes as Attrs
+import Plot.Types exposing (Point)
 import Plot exposing (..)
 import Plot.Area as Area
 import Plot.Axis as Axis
@@ -10,7 +11,7 @@ import Plot.Axis as Axis
 -- Example inspired by https://developer.mozilla.org/en-US/docs/Web/SVG/Tutorial/Gradients
 
 
-data : List ( Float, Float )
+data : List Point
 data =
     [ ( 0, 10 ), ( 2, 12 ), ( 4, 27 ), ( 6, 25 ), ( 8, 46 ) ]
 

--- a/examples/Interactive.elm
+++ b/examples/Interactive.elm
@@ -5,6 +5,7 @@ import Svg.Events
 import Svg.Attributes
 import Html exposing (h1, p, text, div, node)
 import Html.Attributes
+import Plot.Types exposing (Point)
 import Plot exposing (..)
 import Plot.Line as Line
 import Plot.Axis as Axis
@@ -55,12 +56,12 @@ update msg model =
 -- VIEW
 
 
-data1 : List ( Float, Float )
+data1 : List Point
 data1 =
     [ ( 0, 2 ), ( 1, 4 ), ( 2, 5 ), ( 3, 10 ) ]
 
 
-data2 : List ( Float, Float )
+data2 : List Point
 data2 =
     [ ( 0, 0 ), ( 1, 5 ), ( 2, 7 ), ( 3, 15 ) ]
 

--- a/examples/SmoothLines.elm
+++ b/examples/SmoothLines.elm
@@ -9,17 +9,17 @@ import Plot.Line as Line
 import Plot.Axis as Axis
 
 
-data1 : List ( Float, Float )
+data1 : List Point
 data1 =
     [ ( 0, 0 ), ( 1, 1 ), ( 2, 2 ), ( 3, 3 ), ( 4, 5 ), ( 5, 8 ), ( 6, 13 ), ( 7, 21 ), ( 8, 34 ), ( 9, 55 ), ( 10, 87 ) ]
 
 
-data2 : List ( Float, Float )
+data2 : List Point
 data2 =
     [ ( 0, 40 ), ( 1, 45 ), ( 2, 35 ), ( 3, 50 ), ( 4, 30 ), ( 5, 55 ), ( 6, 20 ), ( 7, 60 ), ( 8, 15 ), ( 9, 65 ), ( 10, 10 ) ]
 
 
-data3 : List ( Float, Float )
+data3 : List Point
 data3 =
     [ ( 0, 60 )
     , ( 1, 60 )

--- a/src/Plot.elm
+++ b/src/Plot.elm
@@ -1,7 +1,6 @@
 module Plot
     exposing
         ( Attribute
-        , Point
         , Style
         , plot
         , plotInteractive
@@ -45,7 +44,7 @@ module Plot
  This means that the types are basically interchangable and you can use the same methods on them.
 
 # Definitions
-@docs Attribute, Element, Point, Style
+@docs Attribute, Element, Style
 
 # Elements
 @docs plot, plotInteractive, xAxis, yAxis, hint, verticalGrid, horizontalGrid, custom
@@ -90,12 +89,6 @@ import Internal.Stuff exposing (..)
 import Internal.Types exposing (..)
 import Internal.Draw exposing (..)
 import Internal.Scale exposing (..)
-
-
-{-| Convenience type to represent coordinates.
--}
-type alias Point =
-    ( Float, Float )
 
 
 {-| Convenience type to represent style.


### PR DESCRIPTION
After I fixed this, I saw there was already [a pull request](https://github.com/terezka/elm-plot/pull/36/) by @matthiaskern

His pull request involves fewer changes and does not require clients to `import Plot.Types exposing (Point)`.
However, this leaves duplicated definitions of Point in [src/Plot.elm](https://github.com/terezka/elm-plot/blob/master/src/Plot.elm#L97) end [src/Plot/Types.elm](https://github.com/terezka/elm-plot/blob/master/src/Plot/Types.elm#L19)

I'm not familiar enough with elm to judge which approach is preferable