### PR TITLE
Change Svg sizing to responsive

### DIFF
--- a/src/Plot.elm
+++ b/src/Plot.elm
@@ -493,9 +493,9 @@ viewPlot ({ size } as config) meta ( svgViews, htmlViews ) =
 
 
 plotAttributes : Config -> List (Html.Attribute msg)
-plotAttributes { size, id, style } =
+plotAttributes { id, style } =
     [ Html.Attributes.class "elm-plot"
-    , Html.Attributes.style <| sizeStyle size ++ style
+    , Html.Attributes.style style
     , Html.Attributes.id id
     ]
 
@@ -510,16 +510,15 @@ plotAttributesInteraction meta =
 viewSvg : Oriented Float -> List (Svg msg) -> Svg msg
 viewSvg { x, y } views =
     Svg.svg
-        [ Svg.Attributes.height (toString y)
-        , Svg.Attributes.width (toString x)
-        , Svg.Attributes.class "elm-plot__inner"
+        [ Svg.Attributes.class "elm-plot__inner"
+        , Svg.Attributes.viewBox
+            ("0 0 "
+                ++ (toString x)
+                ++ " "
+                ++ (toString y)
+            )
         ]
         views
-
-
-sizeStyle : Oriented Float -> Style
-sizeStyle { x, y } =
-    [ ( "height", toPixels y ), ( "width", toPixels x ) ]
 
 
 viewElements : Meta -> List (Element msg) -> ( List (Svg msg), List (Html msg) )


### PR DESCRIPTION
Hello.

Thanks for sharing this library!

This patch just implements what @jwillem pointed as the simplest solution in #14 .

It's a big change to users since a sized wrapper should be required for the plot to not take the entire container. I think one of the best parts of Svg is the responsiveness and vector-ish approach, so in my opinion it makes sense to have a responsive behavior at the Svg side and delegate the absolute sizing to users.

If you want I can make this patch as an addition instead of a change so backwards compatibility is preserved.

Also if you want I can try to replace "size" by a viewbox attribute.

What do you think?