### PR TITLE
Render customAttrs for Scatter.

### DIFF
--- a/src/Internal/Scatter.elm
+++ b/src/Internal/Scatter.elm
@@ -23,14 +23,19 @@ defaultConfig =
 
 
 view : Meta -> Config a -> List Point -> Svg.Svg a
-view meta { style, radius } points =
+view meta { style, radius, customAttrs } points =
     let
         svgPoints =
             List.map meta.toSvgCoords points
+            
+        svgAttrs =
+          List.append
+            [ Svg.Attributes.style (toStyle style) ]
+            customAttrs
     in
         Svg.g
-            [ Svg.Attributes.style (toStyle style) ]
-            (List.map (toSvgCircle radius) svgPoints)
+          svgAttrs
+          (List.map (toSvgCircle radius) svgPoints)
 
 
 toSvgCircle : Int -> Point -> Svg.Svg a


### PR DESCRIPTION
`Scatter.customAttrs` was being ignored by `Scatter.view`.

The behavior of simply appending the `customAttrs` was a bit surprising as `Svg.Attributes.style` does not behave like `Html.Attributes.style`; In `Svg` the last style will override the others instead of being accumulated into a list of styles. I've included `customAttrs` last so that its style takes precedence, which was a bit confusing when it overrode `Scatter.fill` and `Scatter.stroke` since those get converted to `style`.